### PR TITLE
fix Conform.Translator.to_config

### DIFF
--- a/lib/conform_translate.ex
+++ b/lib/conform_translate.ex
@@ -34,40 +34,42 @@ defmodule Conform.Translate do
   """
   @spec to_config(term, term) :: term
   def to_config(conf, schema) do
+    normalized_conf = Enum.into(conf, HashDict.new, fn({setting, value}) ->
+                    key = String.to_atom(setting |> Enum.map(&List.to_string/1) |> Enum.join("."))
+                    {key, value}
+                  end)
     case schema do
       [mappings: mappings, translations: translations] ->
-        # Parse the .conf into a map of applications and their settings, applying translations where defined
-        settings = Enum.reduce conf, %{}, fn {setting, value}, result ->
-          # Convert the parsed setting key into the atom used in the schema
-          key = String.to_atom(setting |> Enum.map(&List.to_string/1) |> Enum.join("."))
-          # Look for a mapping with the provided name
-          case Keyword.get(mappings, key) do
-            # If no mapping is defined, just return the current config map,
-            nil  -> result
-            # Otherwise, parse the config for this mapping
-            info ->
-              # Get the translation function if one is defined
-              translation        = Keyword.get(translations, key)
-              # Break the setting key name into [app, and setting]
-              [app, app_setting] = Keyword.get(info, :to, key |> Atom.to_string) |> String.split(".", parts: 2)
-              # Get the default value for this mapping, if defined
-              default_value      = Keyword.get(info, :default, nil)
-              # Get the datatype for this mapping, falling back to binary if not defined
-              datatype           = Keyword.get(info, :datatype, :binary)
-              # Parse the provided value according to the defined datatype
-              parsed_value = case parse_datatype(datatype, value, setting) do
-                nil -> default_value
+        # Parse the schema into a map of applications and their settings, applying conf overrides and translations as specified
+        settings = Enum.reduce mappings, %{}, fn {key, mapping}, result ->
+
+          # Get the datatype for this mapping, falling back to binary if not defined
+          datatype = Dict.get(mapping, :datatype, :binary)
+
+          # conf value takes precident over mapping default
+          default_value = Dict.get(mapping, :default, nil)
+          parsed_value = case Dict.get(normalized_conf, key) do
+            nil        -> default_value
+            conf_value ->
+              case parse_datatype(datatype, conf_value, key) do
+                nil -> conf_value
                 val -> val
               end
-              # Translate parsed value if translation exists
-              translated_value = case translation do
-                fun when is_function(fun) -> fun.(parsed_value)
-                _                         -> parsed_value
-              end
-              # Add the setting for the given app if one doesn't exist, or update if it does
-              current = Map.get(result, app, %{})
-              Map.put(result, app, Map.put(current, app_setting, translated_value))
           end
+
+          # Break the schema setting key name into [app, and setting]
+          [app_name|app_setting] = Dict.get(mapping, :to, key |> Atom.to_string) |> String.split(".")
+
+          # Translate parsed value if translation exists
+          translated_value = case Dict.get(translations, key) do
+            fun when is_function(fun) -> fun.(parsed_value)
+            _                         -> parsed_value
+          end
+
+          # Add the setting for the given app if one doesn't exist, or update if it does
+          app_settings = Map.get(result, app_name, %{})
+          app_settings = update_app_settings(app_settings, app_setting, translated_value)
+          Map.put(result, app_name, app_settings)
         end
         # Convert config map to Erlang config terms
         settings |> settings_to_config
@@ -76,15 +78,35 @@ defmodule Conform.Translate do
     end
   end
 
+  def update_app_settings(app_settings, key_path, value) do
+    update_in_map(app_settings, key_path, value)
+  end
+
+  defp update_in_map(map, [key], value) do
+    Map.put(map, key, value)
+  end
+  defp update_in_map(map, [key|path], value) do
+    nested_map = Map.get(map, key, %{})
+    nested_map = update_in_map(nested_map, path, value)
+    Map.put(map, key, nested_map)
+  end
+
   # Add a .conf-style comment to the given line
   defp add_comment(line), do: "# #{line}"
 
   # Convert config map to Erlang config terms
   # End result: [{:app, [{:key1, val1}, {:key2, val2}, ...]}]
-  defp settings_to_config(settings) do
-    for {app, settings} <- settings, into: [] do
-      { app |> String.to_atom, (for {k, v} <- settings, into: [], do: {k |> String.to_atom, v}) }
-    end
+  def settings_to_config(settings) do
+    setting_to_config(settings)
+  end
+
+  defp setting_to_config(map) when is_map(map) do
+    Enum.map(map, fn({k, v}) ->
+      {k |> String.to_atom, setting_to_config(v)}
+    end)
+  end
+  defp setting_to_config(value) do
+    value
   end
 
   # Parse the provided value as a value of the given datatype


### PR DESCRIPTION
iterates over the schema file grabbing overrides from .conf (if they are defined) and applying any associated translation function.

Also adds support for N level nesting instead of just 2 levels
