### PR TITLE
raise error when reading malformed schema files

### DIFF
--- a/lib/conform/schema.ex
+++ b/lib/conform/schema.ex
@@ -83,34 +83,11 @@ defmodule Conform.Schema do
           raise SchemaError
       end
     else
-      raise SchemaError, message: "Schema at #{path} doesn't exist!"
+      empty
     end
   end
   def read!(name) when is_atom(name) do
     schema_path(name) |> read!
-  end
-
-  @doc """
-  Reads a schema file as quoted terms. If there
-  is a problem parsing the schema, or it doesn't exist, an empty
-  default schema is returned. This is used for manipulating
-  the schema (such as merging, etc.)
-  """
-  @spec read(binary | atom) :: schema
-  def read(path) when is_binary(path) do
-    if path |> File.exists? do
-      case path |> File.read! |> Code.string_to_quoted do
-        {:ok, [mappings: _, translations: _] = schema} ->
-          schema
-        _ ->
-          empty
-      end
-    else
-      empty
-    end
-  end
-  def read(name) when is_atom(name) do
-    schema_path(name) |> read
   end
 
   @doc """
@@ -125,7 +102,7 @@ defmodule Conform.Schema do
     # Merge schemas for all deps
     Mix.Dep.loaded([])
     |> Enum.map(fn %Mix.Dep{app: app, opts: opts} ->
-         Mix.Project.in_project(app, opts[:dest], proj_config, fn _ -> read(app) end)
+         Mix.Project.in_project(app, opts[:dest], proj_config, fn _ -> read!(app) end)
        end)
     |> coalesce
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -17,8 +17,8 @@ defmodule IntegrationTest do
   end
 
   test "test merging and stringifying master/dep schemas" do
-    master = Path.join(["test", "schemas", "merge_master.schema.exs"]) |> Conform.Schema.read
-    dep    = Path.join(["test", "schemas", "merge_dep.schema.exs"]) |> Conform.Schema.read
+    master = Path.join(["test", "schemas", "merge_master.schema.exs"]) |> Conform.Schema.read!
+    dep    = Path.join(["test", "schemas", "merge_dep.schema.exs"]) |> Conform.Schema.read!
     saved  = Path.join(["test", "schemas", "merged_schema.exs"])
 
     # Get schemas from all dependencies
@@ -35,7 +35,7 @@ defmodule IntegrationTest do
     schema = Path.join(["test", "schemas", "merge_master.schema.exs"]) |> Conform.Schema.load
 
     effective = Conform.Translate.to_config([], conf, schema)
-    expected  = [lager: [ 
+    expected  = [lager: [
                   handlers: [
                     lager_console_backend: :info,
                     lager_file_backend: [file: "/var/log/error.log", level: :error],


### PR DESCRIPTION
the existing `read/1` and `read!/1` are less than desirable. `read/1` is used when coalescing schema files and if any schema is malformed it ignored. It is much more desirable to raise an error in this case. 

the functionality we really want from `read`/`read!` is
1. use an empty schema if the file DNE
2. use a well formed schema
3. raise an error for a bad schema
