### PR TITLE
consider pascal-cased . delimited keys as a single key

### DIFF
--- a/test/conf_translate_test.exs
+++ b/test/conf_translate_test.exs
@@ -38,6 +38,9 @@ defmodule ConfTranslateTest do
     # Allowed values: active, passive, active-debug
     myapp.another_val = active
 
+    # Atom module name
+    myapp.Elixir.Some.Module.val = foo
+
     """
   end
 
@@ -55,6 +58,7 @@ defmodule ConfTranslateTest do
       ],
       logger: [format: "$time $metadata[$level] $levelpad$message\n"],
       myapp: [
+        {Some.Module, [val: :foo]},
         another_val: {:on, [data: %{log: :warn}]},
         db: [hosts: [{"127.0.0.1", "8001"}]],
         some_val: :bar
@@ -90,9 +94,10 @@ defmodule ConfTranslateTest do
       ],
       logger: [format: "$time $metadata[$level] $levelpad$message\n"],
       myapp: [
+        {Some.Module, [val: :foo]},
         another_val: {:on, [data: %{log: :warn}]},
         db: [hosts: [{"127.0.0.1", "8001"}]],
-        some_val: :bar
+        some_val: :bar,
       ],
       sasl:  [errlog_type: :progress]
     ]

--- a/test/schemas/test.schema.exs
+++ b/test/schemas/test.schema.exs
@@ -57,6 +57,11 @@
       * passive: it's going to be passive
       * active-debug: it's going to be active, with verbose debugging information
       """
+    ],
+    "myapp.Elixir.Some.Module.val": [
+      datatype: :atom,
+      default:  :foo,
+      doc:      "Atom module name"
     ]
   ],
 


### PR DESCRIPTION
This commit (w/ tests) allows for the usage of Module.Names as keys.

This is related to https://github.com/bitwalker/conform/issues/16