### PR TITLE
Do not start extra shell for compiling escript

### DIFF
--- a/lib/mix/tasks/conform.release.ex
+++ b/lib/mix/tasks/conform.release.ex
@@ -67,11 +67,7 @@ defmodule Mix.Tasks.Conform.Release do
   defp build_escript() do
     escript_path = Path.join(File.cwd!, "conform")
     # Run escript task
-    case Mix.Shell.cmd("mix escript.build", fn _ -> nil end) do
-      0 -> escript_path
-      _ ->
-        Utils.error "Failed to build conform escript!"
-        exit(1)
-    end
+    :ok = Mix.Task.run("escript.build")
+    escript_path
   end
 end


### PR DESCRIPTION
I've tried almost many hours to find the problem. If I download it from hex, it works, if I download it with my fix from github( https://github.com/liveforeverx/conform/tree/corrupting_case or with https://github.com/liveforeverx/exrm/tree/fix_conform ), it doesn't.

After investigation, I've found, that Mix.Shell.cmd "mix build.escript" failes on using conform.release from an app, which has conform as dependency, because it can't find neotoma dependency(I've overwritten the output fun to not ignore output), as it doesn't see themself in dependency context...There is a code, to set `Mix.Project.in_project(:conform, ...` which should not really work with Mix.Shell (as it starts a new VM without knowing enviroments, I do not know, how and why it works with hex-downloaded depencies).
But to fix a problem, the tasks should be started within VM as `Mix.Task.run` to use the right enviroment.

Downside, we see output of compiling conform, but if something will go wrong with compilation, the error willn't be silently dropped, what is much better in my opinion.