### PR TITLE
Delete :import key after schemas merging.

### DIFF
--- a/lib/mix/tasks/conform.effective.ex
+++ b/lib/mix/tasks/conform.effective.ex
@@ -82,8 +82,8 @@ defmodule Mix.Tasks.Conform.Effective do
         end
     end
     # Load merged schemas
-    app_schema = Conform.Schema.schema_path(app) |> Conform.Schema.load! |> Dict.delete(:import)
-    schema = Conform.Schema.coalesce |> Conform.Schema.merge(app_schema)
+    app_schema = Conform.Schema.schema_path(app) |> Conform.Schema.load!
+    schema = Conform.Schema.coalesce |> Conform.Schema.merge(app_schema) |> Dict.delete(:import)
     # Translate .conf -> config, using settings from config if one is
     # not provided in the .conf. If no setting is present in either
     # the config, or the .conf, the default from the schema is used.


### PR DESCRIPTION
Hello @bitwalker,

Little fix here, It is more safely to remove :import key after merge.