### PR TITLE
fix false regex on complex types

### DIFF
--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -285,7 +285,7 @@ defmodule Conform.Translate do
   defp get_in_complex(name, normalized_conf, [key]) do
     res = Enum.filter(normalized_conf,
       fn {complex_key, _} ->
-        {_, pattern} = Regex.compile(Atom.to_string(key))
+        {_, pattern} = key |> Atom.to_string |> String.replace(".*.", "\\.[\\w]+\\.") |> Regex.compile
         case Regex.run(pattern, Atom.to_string(complex_key)) do
           nil -> false
           _   -> true

--- a/test/confs/complex_example.conf
+++ b/test/confs/complex_example.conf
@@ -4,10 +4,14 @@ complex_list.buzz.type = person
 complex_list.buzz.age  = 25
 complex_list.fido.type = dog
 
+complex_another_list.first.id = 100
 complex_another_list.first.username = "test_username1"
 complex_another_list.first.age = 20
+complex_another_list.first.dbid = 1
+complex_another_list.second.id = 101
 complex_another_list.second.username = "test_username2"
 complex_another_list.second.age = 40
+complex_another_list.second.dbid = 1
 
 sublist_example.opt1 = val1
 sublist_example."opt-2" = val2

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -59,8 +59,8 @@ defmodule IntegrationTest do
     effective = Conform.Translate.to_config([], conf, schema)
     expected = [my_app:
                 [complex_another_list:
-                 [first: %{age: 20, username: "test_username1"},
-                  second: %{age: 40, username: "test_username2"}],
+                 [first: %{id: 100, dbid: 1, age: 20, username: "test_username1"},
+                  second: %{id: 101, dbid: 1, age: 40, username: "test_username2"}],
                  complex_list: [
                    buzz: %{age: 25, type: :person}, fido: %{age: 30, type: :dog}],
                  some_val: :foo, some_val2: 2.5,

--- a/test/schemas/complex_schema.exs
+++ b/test/schemas/complex_schema.exs
@@ -8,6 +8,16 @@
       datatype: [:complex],
       default: []
     ],
+    "complex_another_list.*.id": [
+      to: "my_app.complex_another_list",
+      datatype: :integer,
+      default: :undefined
+    ],
+    "complex_another_list.*.dbid": [
+      to: "my_app.complex_another_list",
+      datatype: :integer,
+      default: :undefined
+    ],
     "complex_another_list.*.username": [
       to: "my_app.complex_another_list",
       datatype: :binary,
@@ -68,8 +78,10 @@
 
     "my_app.complex_another_list.*": fn _, {key, value_map}, acc ->
       [{key, %{
+        id: value_map[:id],
         username: value_map[:username],
-        age: value_map[:age]
+        age: value_map[:age],
+        dbid: value_map[:dbid]
        }} | acc]
     end,
 


### PR DESCRIPTION
fix bug in the of complex type matching. add tests.

```
** (CaseClauseError) no case clause matching: ["complex_another_list.first.dbid": '1', "complex_another_list.first.id": '100']
    (conform) lib/conform/translate.ex:305: Conform.Translate.get_in_complex/3
    (conform) lib/conform/translate.ex:218: anonymous fn/3 in Conform.Translate.get_complex/3
     (elixir) lib/enum.ex:1043: anonymous fn/3 in Enum.map/2
     (elixir) lib/enum.ex:1385: Enum."-reduce/3-lists^foldl/2-0-"/3
     (elixir) lib/enum.ex:1043: Enum.map/2
    (conform) lib/conform/translate.ex:211: anonymous fn/5 in Conform.Translate.get_complex/3
     (elixir) lib/enum.ex:1043: anonymous fn/3 in Enum.map/2
     (elixir) lib/enum.ex:1385: Enum."-reduce/3-lists^foldl/2-0-"/3
```