### PR TITLE
Add support for empty string in default value for a custom data type

### DIFF
--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -486,7 +486,12 @@ defmodule Conform.Translate do
     converted = write_datatype(type, v, setting)
     <<Atom.to_string(k)::binary, " = ", converted::binary>>
   end
-  defp write_datatype(_datatype, value, _setting), do: "#{value}"
+  defp write_datatype(_datatype, value, _setting) do
+    case "#{value}" do
+      "" -> <<?", "#{value}", ?">>
+      _ -> "#{value}"
+    end
+  end
 
   defp to_comment(str) do
     String.split(str, "\n", trim: true) |> Enum.map(&add_comment/1) |> Enum.join("\n")


### PR DESCRIPTION
Custom datatype may have default value - "". In this way, we will get
empty string in the foo.conf file, like:

```
foo =
```

This patch provides fix for this