### PR TITLE
conform: Add support for ':to' attribute in the mappings with complex…

### DIFF
--- a/test/schemas/merged_schema.exs
+++ b/test/schemas/merged_schema.exs
@@ -62,7 +62,7 @@
       _mapping, level, acc when level in [:info, :error] ->
         acc ++ [lager_console_backend: level]
       _mapping, level, _ ->
-        IO.puts(<<"Unsupported console logging level: ", Kernel.to_string(level) :: binary>>)
+        IO.puts("Unsupported console logging level: #{level}")
         exit(1)
     end,
     "lager.handlers.file.error": fn


### PR DESCRIPTION
… types

Previously, a mapping with a complex data type can't have ':to' attribute that
name differs from the mapping name. For example:

"my_app.complex_list.*": [
    ...
    ...
    ...
    datatype: [:complex],
    to: "my_app.Elixir.Data.lists",
    ...
],

This patch provides support for this case.