### PR TITLE
Add Mix.env to .conf filename

### DIFF
--- a/lib/mix/tasks/conform.configure.ex
+++ b/lib/mix/tasks/conform.configure.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Conform.Configure do
   defp do_run(_) do
     app         = Mix.Project.config |> Keyword.get(:app)
     schema_path = Conform.Schema.schema_path(app)
-    output_path = Path.join([File.cwd!, "config", "#{app}.conf"])
+    output_path = Path.join([File.cwd!, "config", "#{app}_#{Mix.env}.conf"])
 
     # Check for conditions which prevent us from continuing
     continue? = case File.exists?(schema_path) do

--- a/lib/mix/tasks/conform.effective.ex
+++ b/lib/mix/tasks/conform.effective.ex
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Conform.Effective do
   defp do_run(args) do
     Mix.Tasks.Loadpaths.run([])
     app       = Mix.Project.config |> Keyword.get(:app)
-    conf_path = Path.join([File.cwd!, "config", "#{app}.conf"])
+    conf_path = Path.join([File.cwd!, "config", "#{app}_#{Mix.env}.conf"])
     # Load the base configuration from config.exs if it exists, and validate it
     # If config.exs doesn't exist, proceed if a .conf file exists, otherwise there
     # is no configuration to display


### PR DESCRIPTION
## What

Add the Mix environment `Mix.env` to the `.conf` filename to allow for easier management of multiple environments.

Configuration file names now look like: `appname_staging.conf` or `appname_prod.conf`
## Why

I've found it exceedingly difficult to manage multiple environment configurations using a single `.conf.` and even more difficult to deploy..

As I said in #60 there seems to be a failing test on master that's not a result of this PR.
