### PR TITLE
Removed warnings by redefining @doc's as @moduledoc's.

### DIFF
--- a/lib/conform/schema.ex
+++ b/lib/conform/schema.ex
@@ -58,10 +58,10 @@ defmodule Conform.Schema do
             transforms: [],
             validators: []
 
-  @doc """
-  This exception reflects an issue with the schema
-  """
   defmodule SchemaError do
+    @moduledoc """
+    This exception reflects an issue with the schema
+    """
     defexception message: "Invalid schema. Should be a keyword list with at least the :mappings key defined"
   end
 

--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -10,10 +10,10 @@ defmodule Conform.Translate do
 
   @type table_identifier :: non_neg_integer() | atom()
 
-  @doc """
-  This exception reflects an issue with the translation process
-  """
   defmodule TranslateError do
+    @moduledoc """
+    This exception reflects an issue with the translation process
+    """
     defexception message: "Translation failed!"
   end
 


### PR DESCRIPTION
When compiling conform, it gave warnings that 2 @doc attributes are being overwritten.
This is because in both schema.ex and translate.ex there is an @doc attribute used for defmodule, which is not correctly parsed. This changes those attributes to @moduledoc attributes, correctly parsing the documentation and removing the warnings.