### PR TITLE
convert merged item back to tuple

### DIFF
--- a/lib/conform/utils/utils.ex
+++ b/lib/conform/utils/utils.ex
@@ -104,7 +104,7 @@ defmodule Conform.Utils do
     extra_count  = :erlang.size(new) - merged_count
 
     case extra_count do
-      0 -> merged
+      0 -> List.to_tuple(merged)
       _ ->
         extra = new
           |> Tuple.to_list


### PR DESCRIPTION
Prior to this commit when conform attempted to merge a term for tuples
it would convert the tuple to a list, but then never convert it back to
a tuple, resulting in sys.configs that looked like
```
ips: [["127.0.0.1", 80], {"::1", 80}]
```
when they should have looked like
```
ips: [{"127.0.0.1", 80], {"::1", 80}]
```
This commit ensures that we convert the initial merged term back into a
tuple before continuing.

Should address #73 