### PR TITLE
add list of tuples tests for Conform.Utils.merge/2

### DIFF
--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,4 +1,18 @@
 defmodule ConformUtilsTest do
   use ExUnit.Case, async: true
   doctest Conform.Utils
+
+  test "list of tuples" do
+    settings = [rooms: [{"one", [:one]}, {"two", [:two]}]]
+    assert Conform.Utils.merge(settings, []) == settings
+    assert Conform.Utils.merge([], settings) == settings
+    assert Conform.Utils.merge(settings, settings) == settings
+  end
+
+  test "list of ips" do
+    ips = [ips: [{"127.0.0.1", "8001"}, {"::1", "8002"}]]
+    assert Conform.Utils.merge(ips, []) == ips
+    assert Conform.Utils.merge([], ips) == ips
+    assert Conform.Utils.merge(ips, ips) == ips
+  end
 end


### PR DESCRIPTION
Prior to this commit we had no tests indicating the expected behaviour
of `Conform.Utils.merge/2` for lists of tuples, either generic or ips,
which meant we had no way to validate fix for GH-73 or guard against
future regression. This commit adds simple tests that something merged
with itself should still be itself, which fails for 2.0.0 and passes as
of 75be712.