### PR TITLE
Distilled umbrella

### DIFF
--- a/lib/conform/releases/plugin.ex
+++ b/lib/conform/releases/plugin.ex
@@ -33,7 +33,9 @@ defmodule Conform.ReleasePlugin do
           end
           conform_overlays
         {_, zip_path, _} ->
-          [{:copy, zip_path, "releases/<%= release_version %>/<%= release_name %>.schema.ez"}|conform_overlays]
+          [{:copy,
+            "#{zip_path}",
+            "releases/<%= release_version %>/<%= release_name %>.schema.ez"}|conform_overlays]
       end
 
       conform_overlays = case File.exists?(conf_src) do

--- a/lib/conform/releases/plugin.ex
+++ b/lib/conform/releases/plugin.ex
@@ -14,7 +14,7 @@ defmodule Conform.ReleasePlugin do
   your release in production.
   """
   def before_assembly(%{profile: %{overlays: overlays} = profile} = release) do
-    conf_src = Path.join([File.cwd!, "config", "#{release.name}.conf"])
+    conf_src = Path.join([Conform.Utils.src_conf_dir(release.name), "#{release.name}.conf"])
     debug "loading schema"
     schema_src = Conform.Schema.schema_path(release.name)
     if File.exists?(schema_src) do

--- a/lib/conform/schema.ex
+++ b/lib/conform/schema.ex
@@ -70,7 +70,10 @@ defmodule Conform.Schema do
   """
   @spec schema_path() :: binary
   def schema_path(),    do: Mix.Project.config |> Keyword.get(:app) |> schema_path
-  def schema_path(app), do: Path.join([File.cwd!, "config", schema_filename(app)])
+  def schema_path(app) do
+    conf_dir = Conform.Utils.src_conf_dir(app)
+    Path.join([conf_dir, schema_filename(app)])
+  end
 
   @doc """
   get the current app's schema filename

--- a/lib/conform/utils/utils.ex
+++ b/lib/conform/utils/utils.ex
@@ -197,4 +197,24 @@ defmodule Conform.Utils do
       put_in(acc, key_path, v)
     end)
   end
+
+  @doc """
+  Indicates whether an app is loaded. Useful to ask whether :distillery
+  is loaded.
+  """
+  def is_app_loaded?(app) do
+    app in Enum.map(Application.loaded_applications, &elem(&1,0) )
+  end
+
+  @doc """
+  Returns dir path for the in-source-tree
+  configuration directory.
+  """
+  def src_conf_dir(app) do
+    if Mix.Project.umbrella? and is_app_loaded?(:distillery) do
+      Path.join([File.cwd!, "apps", "#{app}", "config"])
+    else
+      Path.join([File.cwd!, "config"])
+    end
+  end
 end


### PR DESCRIPTION
Several fixes for distillery+conform with umbrella projects.

* Depends on https://github.com/bitwalker/distillery/pull/77
* Fixes https://github.com/bitwalker/distillery/issues/56

My patches introduce functions that figure out whether we should prepend `apps/foo` to `config`. I intended to apply them to all code locations that tried to get the schema and `.conf` file 'source' paths, but I didn't. I realized that we have an odd situation:

* When called during other mix actions -- `conform.new` for example -- we can rely on `cwd` being "in" the `apps/foo` directory.
* During `release`, `cwd` is at the top of the umbrella.

Right now we can't consolidate codepaths that use `cwd` between `release` and other actions. 