### PR TITLE
archive: Fix .ez archive file for schemas that 'import' from umbrella

### DIFF
--- a/lib/mix/tasks/conform.archive.ex
+++ b/lib/mix/tasks/conform.archive.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Conform.Archive do
               app_path = Path.join([curr_path, "deps", "#{app_name}"])
               {app_name, Path.join([app_path, "config", "#{app_name}.schema.exs"])}
             {app_name, path_to_app} ->
-              {app_name, Path.join([curr_path, path_to_app, "config", "fake_app.schema.exs"])}
+              {app_name, Path.join([curr_path, path_to_app, "config", "#{app_name}.schema.exs"])}
           end
           if File.exists?(src_path) do
             dest_path = Path.join(["#{app}", "config", "#{app}.schema.exs"])


### PR DESCRIPTION
Collecting 'imported' schemas in the umbrella is fixed with this patch,
which removes an accidental test environment variable from live code.

==============

An umbrella project with a schema saying `import: [ :app_one ]` would fail to include `app_one.schema.exs` in its archive `.ez` file because it was looking up `fake_app.schema.exs`, with the literal "fake_app" accidentally hardcoded.

This is visible with umbrella projects built under `distillery`. When built under `exrm`, the codepath followed is slightly different.