### PR TITLE
Allow the release name to differ from umbrella app

### DIFF
--- a/lib/conform/utils/utils.ex
+++ b/lib/conform/utils/utils.ex
@@ -211,8 +211,9 @@ defmodule Conform.Utils do
   configuration directory.
   """
   def src_conf_dir(app) do
-    if Mix.Project.umbrella? and is_app_loaded?(:distillery) do
-      Path.join([File.cwd!, "apps", "#{app}", "config"])
+    umbrella_app = Path.join([File.cwd!, "apps", "#{app}"])
+    if Mix.Project.umbrella? and is_app_loaded?(:distillery) and File.exists?(umbrella_app) do
+      Path.join([umbrella_app, "config"])
     else
       Path.join([File.cwd!, "config"])
     end


### PR DESCRIPTION
By default it seems Distillery / Conform map the release name
to a "master" application within the umbrella. Only from that master
application one can "extend" the child applications to create a
dependency tree of schema's used for setting default values,
transformations, validations, etc.

With this change, behaviour remains the same when not in an umbrella
or when in an umbrella and an application actually exists which has
the same name as the release.
But if it doesn't, it will fall back to a configuration with the name
of the release inside the umbrella config directory.

for example:

umbrella_dir/
  + config/
    + my_release.schema.exs
    + my_release.conf
  + apps/
    + app1/
    + app2/
  + rel/
    + config.exs

my_release.schema.exs contains:

[
  extends:    [ :app1, :app2 ],
  import:     [],
  mappings:   [],
  transforms: [],
  validators: []
]

rel/config.exs contains:

use Mix.Releases.Config,
	default_release: :my_release,
	default_environment: Mix.env

release :my_release do
	plugin Conform.ReleasePlugin
	set ..etc
end