### PR TITLE
Fix handling of unicode strings

### DIFF
--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -271,6 +271,13 @@ defmodule Conform.Translate do
     end
   end
 
+  defp sanitize(value) when is_list(value) do
+    #this is neccessary for utf8 multibyte content:
+    value
+    |> Enum.map(&(<<&1>>))
+    |> Enum.join
+    |> sanitize()
+  end
   defp sanitize(value) do
     bin_value = to_string(value)
     size = byte_size(bin_value) - 2

--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -274,8 +274,7 @@ defmodule Conform.Translate do
   defp sanitize(value) when is_list(value) do
     #this is neccessary for utf8 multibyte content:
     value
-    |> Enum.map(&(<<&1>>))
-    |> Enum.join
+    |> :erlang.iolist_to_binary
     |> sanitize()
   end
   defp sanitize(value) do


### PR DESCRIPTION
unicode strings come as lists from `:conform_parse.file(path)`
`to_string` can not handle this correctly.
here we assemble the single bytes so elixir understands the utf8 content again.