### PR TITLE
Fix schema extensions in umbrella applications

### DIFF
--- a/lib/conform/schema.ex
+++ b/lib/conform/schema.ex
@@ -400,7 +400,7 @@ defmodule Conform.Schema do
   defp get_extends_schema(app_name, src_schema_path) do
     # Attempt loading from deps if Mix is available
     schema_path = try do
-      paths = Mix.Dep.children
+      paths = Mix.Dep.loaded(env: Mix.env)
               |> Enum.filter(fn %Mix.Dep{app: app} -> app == app_name end)
               |> Enum.map(fn %Mix.Dep{opts: opts} ->
                 Keyword.get(opts, :dest, Keyword.get(opts, :path))


### PR DESCRIPTION
I found a bug in the function that finds the schemas for extension.

I was trying to extend a schema in a umbrella application and it was returning only: `Schema extends xxxx, but the schema for xxxx was not found.`, although the schema was clearly present.

Digging through the code, I found that the function `Mix.Dep.children/0` was removed since [Mix v1.3.](https://github.com/elixir-lang/elixir/commit/e6e52d6d1e224b697c5b46726ed06b186d86ab23) It seems that it was replaced by the `Mix.Dep.cached/0`, but because conform is compatible with Elixir v1.0 and up, I chose to use the `Mix.Dep.loaded/1` function that maintains the compatibility.

It now finds the correct schemas and I think it might solve some issues people are having with configuration in umbrella applications.