### PR TITLE
Create failing spec to demonstrate list order issue

### DIFF
--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -6,7 +6,7 @@ defmodule ConfigTest do
   test "can load config.exs containing nested lists" do
     path   = Path.join(["test", "configs", "nested_list.exs"])
     config = path |> Mix.Config.read!
-    assert [my_app: [sublist: [[opt1: "val1", opt2: "val4"], [opt1: "val3", opt2: "val4"]],
+    assert [my_app: [sublist: [[opt1: "val3", opt2: "val4"], [opt1: "val1", opt2: "val4"]],
                      rx_pattern: [~r/[A-Z]+/]]] == config
   end
 
@@ -20,7 +20,7 @@ defmodule ConfigTest do
               doc: "Provide documentation for my_app.sublist here.",
               to: "my_app.sublist",
               datatype: [list: [list: {:atom, :binary}]],
-              default: [[opt1: "val1", opt2: "val4"], [opt1: "val3", opt2: "val4"]]
+              default: [[opt1: "val3", opt2: "val4"], [opt1: "val1", opt2: "val4"]]
             },
             %Mapping{
               name: "my_app.rx_pattern",
@@ -39,6 +39,6 @@ defmodule ConfigTest do
     {:ok, conf} = Path.join(["test", "confs", "nested_list.conf"]) |> Conform.Conf.from_file
     sysconfig = Conform.Translate.to_config(schema, config, conf)
     assert [my_app: [rx_pattern: [~r/[A-Z]+/],
-                     sublist: [[opt1: "val1", opt2: "val two"], [opt1: "val3", opt2: "val-4"]]]] == sysconfig
+                     sublist: [[opt1: "val3", opt2: "val-4"], [opt1: "val1", opt2: "val two"]]]] == sysconfig
   end
 end

--- a/test/configs/nested_list.exs
+++ b/test/configs/nested_list.exs
@@ -3,11 +3,11 @@ use Mix.Config
 config :my_app,
   sublist: [
     [
-      opt1: "val1",
+      opt1: "val3",
       opt2: "val4"
     ],
     [
-      opt1: "val3",
+      opt1: "val1",
       opt2: "val4"
     ]
   ],


### PR DESCRIPTION
# Why?
I have a project where we define config with a list.  It looks something like this:

```
config :product_catalog, :frequently_purchased_with_recommendation_services, [
  {ProductCatalog.Recommendations.Service.Local, %{
    code: "<redacted>",
    customer_id: "<redacted>",
    page_template: "<redacted>",
    placeholder_name: "<redacted>",
    product_id_attribute_name: "<redacted>"
  }},
  {ProductCatalog.Recommendations.Service.Baynote, %{
    code: "<redacted>",
    customer_id: "<redacted>",
    page_template: "<redacted>",
    placeholder_name: "<redacted>",
    product_id_attribute_name: "<redacted>"
  }}
]
```

We (want to) do some stuff with the order of this list in the app - however conform seems to be chewing up the list when it translates the list to sys.config. To try to understand what is going on I changed the order of `configs/nested_list.exs` and then altered the assertions in ConfigTest to match my expectation (that the lists would be in the new order) and sure enough "can translate config.exs + schema + conf with nested lists to sys.config"

Maybe I'm missing something?
