### PR TITLE
Sort mappings

### DIFF
--- a/lib/conform/schema.ex
+++ b/lib/conform/schema.ex
@@ -323,7 +323,7 @@ defmodule Conform.Schema do
     schema |> Map.to_list |> Keyword.delete(:__struct__) |> Enum.map(&to_list/1)
   end
   defp to_list({k, v}) when is_list(v) do
-    {k, Enum.map(v, &to_list/1)}
+    {k, Enum.map(Enum.sort(v, &do_sort/2), &to_list/1)}
   end
   defp to_list(%Conform.Schema.Validator{name: nil, definition: nil, validator: v}), do: v
   defp to_list(%Conform.Schema.Validator{name: name, definition: v}), do: {String.to_atom(name), v}
@@ -344,6 +344,14 @@ defmodule Conform.Schema do
   defp to_list(v) when is_map(v) do
     v |> Map.to_list |> Keyword.delete(:__struct__)
   end
+
+  defp do_sort(m1, m2) do
+    key(m1) <= key(m2)
+  end
+
+  defp key(%Conform.Schema.Mapping{name: name}), do: name
+  defp key(%Conform.Schema.Validator{name: name}), do: name
+  defp key(k), do: k
 
   @doc """
   Convert standard configuration to quoted schema format

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -100,6 +100,18 @@ defmodule IntegrationTest do
       extends: [],
       import: [],
       mappings: [
+        "my_app.rx_pattern": [
+          commented: false,
+          datatype: [
+            list: :binary
+          ],
+          default: [
+            ~r/[A-Z]+/
+          ],
+          doc: "Provide documentation for my_app.rx_pattern here.",
+          hidden: false,
+          to: "my_app.rx_pattern"
+        ],
         "my_app.sublist": [
           commented: false,
           datatype: [
@@ -114,18 +126,6 @@ defmodule IntegrationTest do
           doc: "Provide documentation for my_app.sublist here.",
           hidden: false,
           to: "my_app.sublist"
-        ],
-        "my_app.rx_pattern": [
-          commented: false,
-          datatype: [
-            list: :binary
-          ],
-          default: [
-            ~r/[A-Z]+/
-          ],
-          doc: "Provide documentation for my_app.rx_pattern here.",
-          hidden: false,
-          to: "my_app.rx_pattern"
         ]
       ],
       transforms: [],


### PR DESCRIPTION
This is a simple patch that will sort the mappings and validators in alphanumeric order.

When you have a large configuration, adding new mappings can be difficult. It is especially difficult to compare the new config file to the old when, when the mappings are in random orders. This patch sorts all the mappings and validators, giving consistent results.