### PR TITLE
Added runtime error if a env_var is missing and there is no default value for a key

### DIFF
--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -136,7 +136,11 @@ defmodule Conform.Translate do
                      nil -> mapping.default
                      var when is_binary(var) ->
                        case System.get_env(var) do
-                         nil -> mapping.default
+                         nil ->
+                           case mapping.default do
+                             nil -> raise missing_env_var(var, key)
+                             default -> default
+                           end
                          val -> parse_datatype(datatype, [val], mapping)
                        end
                    end
@@ -174,7 +178,11 @@ defmodule Conform.Translate do
           nil -> mapping.default
           var ->
             case System.get_env(var) do
-              nil -> mapping.default
+              nil ->
+                case mapping.default do
+                  nil -> raise missing_env_var(var, key)
+                  default -> default
+                end
               val -> parse_datatype(datatype, [val], mapping)
             end
         end
@@ -244,7 +252,11 @@ defmodule Conform.Translate do
           {stripped, default}
         var ->
           case System.get_env(var) do
-            nil -> {stripped, default}
+            nil ->
+              case default do
+                nil -> raise missing_env_var(var, key)
+                default -> {stripped, default}
+              end
             val -> {stripped, parse_datatype(mapping.datatype, [val], mapping)}
           end
       end
@@ -529,4 +541,7 @@ defmodule Conform.Translate do
     |> Enum.join(".")
   end
 
+  defp missing_env_var(var, key) do
+    "Configuration Error: environment variable $#{var} is not set and no default value for #{key} is present."
+  end
 end

--- a/lib/conform/translate.ex
+++ b/lib/conform/translate.ex
@@ -136,11 +136,7 @@ defmodule Conform.Translate do
                      nil -> mapping.default
                      var when is_binary(var) ->
                        case System.get_env(var) do
-                         nil ->
-                           case mapping.default do
-                             nil -> raise missing_env_var(var, key)
-                             default -> default
-                           end
+                         nil -> mapping.default
                          val -> parse_datatype(datatype, [val], mapping)
                        end
                    end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -160,4 +160,15 @@ defmodule ConfigTest do
     assert [my_app: [rx_pattern: [~r/[A-Z]+/],
                      sublist: [[opt1: "val1", opt2: "val two"], [opt1: "val3", opt2: "val-4"]]]] == sysconfig
   end
+
+  test "raises runtime error if env var value is missing and there is no default value" do
+    schema_path = Path.join(["test", "schemas", "env_var.schema.exs"])
+    schema = Conform.Schema.load!(schema_path)
+    conf_path = Path.join(["test", "confs", "test.conf"])
+    {:ok, conf} = Conform.Conf.from_file(conf_path)
+
+    assert_raise RuntimeError, ~r/^Configuration Error/, fn ->
+      Conform.Translate.to_config(schema, [], conf)
+    end
+  end
 end

--- a/test/schemas/env_var.schema.exs
+++ b/test/schemas/env_var.schema.exs
@@ -1,0 +1,12 @@
+[
+  extends: [],
+  import: [],
+  mappings: [
+    "envvarconfig": [
+      to: "envvarconfig",
+      datatype: :integer,
+      env_var: "NOT_SET"
+    ]
+  ],
+  transforms: []
+]


### PR DESCRIPTION
The main problem this addition tries to solve is the cases when an environment variable was not set (due to human error) and no one noticed this misconfiguration, because `nil` was used as a fallback/default. 

The error is raised only if a `default` is not set in the schema.