### PR TITLE
Modify code to fix a transform error.

### DIFF
--- a/test/conf_translate_test.exs
+++ b/test/conf_translate_test.exs
@@ -209,4 +209,16 @@ defmodule ConfTranslateTest do
     """
     assert expected == conf
   end
+
+  test "check transform overwrite" do
+    path = Path.join(["test", "schemas", "transform_overwrite_schema.exs"])
+    schema = Conform.Schema.load!(path)
+    conf = """
+    fld1.fld2.fld3=3
+    fld1.fld2.fld4=4
+    """
+    {:ok, parsed} = Conform.Conf.from_binary(conf)
+    config = Conform.Translate.to_config(schema, [], parsed)
+    assert config == [fld1: [%{fld3: 3, fld4: 4}]]
+  end
 end

--- a/test/schemas/transform_overwrite_schema.exs
+++ b/test/schemas/transform_overwrite_schema.exs
@@ -1,0 +1,29 @@
+[
+  mappings: [
+    "fld1.fld2.fld3": [
+      to: "fld1.fld2.fld3",
+      datatype: :integer,
+      default: :undefined
+    ],
+    "fld1.fld2.fld4": [
+      to: "fld1.fld2.fld4",
+      datatype: :integer,
+      default: :undefined
+    ]
+  ],
+  transforms: [
+    "fld1": fn conf ->
+      Enum.reduce(Conform.Conf.get(conf, "fld1.$node1.$node2"), %{},
+      fn({['fld1', node1, node2], val}, acc) ->
+        key = String.to_atom(to_string(node2))
+        case acc[node1] do
+          nil ->
+            Map.put(acc, node1, %{ key => val })
+          map ->
+            Map.put(acc, node1, Map.put(map, key, val))
+        end
+      end)
+      |> Map.values
+    end
+  ]
+]


### PR DESCRIPTION
This is a bit convoluted, but I'll try to explain the issue as best I can.

I created a unit test which demonstrates the issue. The test is located in test/conf_translate_test.exs at line 213. Under the current 2.5.2 version of conform, this test will fail. I reworked some code in translate.ex to get around the issue. I am using Elixir 1.4.5 running on top of Erlang 19.3. It's possible this may not happen in the latest versions of Elixir and Erlang, but I just don't have time right now to try it.

The test I added fails under 2.5.2 with the following error:
```
** (FunctionClauseError) no function clause matching in Keyword.get_and_update/4
     (elixir) lib/keyword.ex:227: Keyword.get_and_update([%{fld3: 3, fld4: 4}], [], :fld2, #Function<12.57371001/1 in Kernel.put_in/3>)
     (elixir) lib/keyword.ex:228: Keyword.get_and_update/4
     (elixir) lib/kernel.ex:1831: Kernel.put_in/3
    (conform) lib/conform/utils/utils.ex:173: anonymous fn/2 in Conform.Utils.results_to_tree/2
     (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    (conform) lib/conform/utils/utils.ex:164: anonymous fn/3 in Conform.Utils.results_to_tree/2
     (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    (conform) lib/conform/translate.ex:118: Conform.Translate.apply_schema/2
```

If a transform tries to rewrite a sub path of a configuration key, it may fail depending on the order the records in the config ets table. From what I can tell the order of entries in an ets table is not related to the order they are inserted for a set type table. The failure occurs in the Conform.Utils.results_to_tree function.

Just as an example if I issue the following calls against an ets table:
```elixir
t = :ets.new(:tab, [:set, keypos: 1])
:ets.insert(['fld1', 'fld2', 'fld3'], 1)
:ets.insert(t, {['fld1', 'fld2', 'fld4'], 1})
:ets.insert(t, {['fld1'], 1})
:ets.tab2list(t)
```
The result is:
```elixir
[{['fld1'], 1}, {['fld1', 'fld2', 'fld3'], 1}, {['fld1', 'fld2', 'fld4'], 1}]
```
You can see the entry inserted last becomes the first in the list, which causes the issue in results_to_tree.

I reworked the code to store transform results in a temporary ets table whose results are merged into the main config table thus making sure they are applied after the main configuration processing.

If the transforms happen to go into the table after their non-transformed entries, it does work.

Of course, there may be a better way to achieve the same result, but I'm going to use my version for now as this has caused me a huge headache trying to deploy to a production system. It took me a few days to figure out what was going on :-)

Please feel free to modify this code or determine if there is a better way to deal with the issue.

Thank you,
Nathan Fox
