### PR TITLE
Allow ignoring of conform configuration

### DIFF
--- a/priv/bin/post_configure.sh
+++ b/priv/bin/post_configure.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ -z "$CONFORM_IGNORE" ]; then
+if [ -z "$RELEASE_MUTABLE_IGNORE" ]; then
     # Set CONFORM_SCHEMA_PATH, the path to the schema.exs file to use
     # Use $RELEASE_CONFIG_DIR/$REL_NAME.schema.exs if exists, otherwise releases/VSN/$REL_NAME.schema.exs
     if [ -z "$CONFORM_SCHEMA_PATH" ]; then

--- a/priv/bin/post_configure.sh
+++ b/priv/bin/post_configure.sh
@@ -1,49 +1,50 @@
 #!/bin/sh
-
-# Set CONFORM_SCHEMA_PATH, the path to the schema.exs file to use
-# Use $RELEASE_CONFIG_DIR/$REL_NAME.schema.exs if exists, otherwise releases/VSN/$REL_NAME.schema.exs
-if [ -z "$CONFORM_SCHEMA_PATH" ]; then
-    if [ -f "$RELEASE_CONFIG_DIR/$REL_NAME.schema.exs" ]; then
-        CONFORM_SCHEMA_PATH="$RELEASE_CONFIG_DIR/$REL_NAME.schema.exs"
-    else
-        CONFORM_SCHEMA_PATH="$REL_DIR/$REL_NAME.schema.exs"
-    fi
-fi
-
-# Set CONFORM_CONF_PATH, the path to the .conf file to use
-# Use $RELEASE_CONFIG_DIR/$REL_NAME.conf if exists, otherwise releases/VSN/$REL_NAME.conf
-if [ -z "$CONFORM_CONF_PATH" ]; then
-    if [ -f "$RELEASE_CONFIG_DIR/$REL_NAME.conf" ]; then
-        CONFORM_CONF_PATH="$RELEASE_CONFIG_DIR/$REL_NAME.conf"
-    else
-        CONFORM_CONF_PATH="$REL_DIR/$REL_NAME.conf"
-    fi
-fi
-
-__schema_destination="$RELEASE_CONFIG_DIR/$REL_NAME.schema.exs"
-__conf_destination="$RELEASE_CONFIG_DIR/$REL_NAME.conf"
-__conform_code_path="$RELEASE_ROOT_DIR/lib/*/ebin"
-
-# Convert .conf to sys.config using conform escript
-if [ -f "$CONFORM_SCHEMA_PATH" ]; then
-    if [ -f "$CONFORM_CONF_PATH" ]; then
-        EXTRA_OPTS="$EXTRA_OPTS -conform_schema ${CONFORM_SCHEMA_PATH} -conform_config $CONFORM_CONF_PATH"
-
-        __conform="$REL_DIR/conform"
-        # Clobbers input sys.config
-        "$BINDIR"/escript "$__conform" --code-path "$__conform_code_path" --conf "$CONFORM_CONF_PATH" --schema "$CONFORM_SCHEMA_PATH" --config "$SYS_CONFIG_PATH" --output-dir "$(dirname $SYS_CONFIG_PATH)"
-        exit_status="$?"
-        if [ "$exit_status" -ne 0 ]; then
-            exit "$exit_status"
+if [ -z "$CONFORM_IGNORE" ]; then
+    # Set CONFORM_SCHEMA_PATH, the path to the schema.exs file to use
+    # Use $RELEASE_CONFIG_DIR/$REL_NAME.schema.exs if exists, otherwise releases/VSN/$REL_NAME.schema.exs
+    if [ -z "$CONFORM_SCHEMA_PATH" ]; then
+        if [ -f "$RELEASE_CONFIG_DIR/$REL_NAME.schema.exs" ]; then
+            CONFORM_SCHEMA_PATH="$RELEASE_CONFIG_DIR/$REL_NAME.schema.exs"
+        else
+            CONFORM_SCHEMA_PATH="$REL_DIR/$REL_NAME.schema.exs"
         fi
-        if ! grep -q '^%%' "$SYS_CONFIG_PATH" ; then
-            tmpfile=$(mktemp "${SYS_CONFIG_PATH}.XXXXXX")
-            echo "%%Generated - edit $RELEASE_CONFIG_DIR/$REL_NAME.conf or $RELEASE_CONFIG_DIR/$REL_NAME.conf/sys.config" >> "$tmpfile"
-            cat "${SYS_CONFIG_PATH}" >> $tmpfile
-            mv "$tmpfile" "${SYS_CONFIG_PATH}"
+    fi
+
+    # Set CONFORM_CONF_PATH, the path to the .conf file to use
+    # Use $RELEASE_CONFIG_DIR/$REL_NAME.conf if exists, otherwise releases/VSN/$REL_NAME.conf
+    if [ -z "$CONFORM_CONF_PATH" ]; then
+        if [ -f "$RELEASE_CONFIG_DIR/$REL_NAME.conf" ]; then
+            CONFORM_CONF_PATH="$RELEASE_CONFIG_DIR/$REL_NAME.conf"
+        else
+            CONFORM_CONF_PATH="$REL_DIR/$REL_NAME.conf"
         fi
-    else
-        echo "missing .conf, expected it at $CONFORM_CONF_PATH"
-        exit 1
+    fi
+
+    __schema_destination="$RELEASE_CONFIG_DIR/$REL_NAME.schema.exs"
+    __conf_destination="$RELEASE_CONFIG_DIR/$REL_NAME.conf"
+    __conform_code_path="$RELEASE_ROOT_DIR/lib/*/ebin"
+
+    # Convert .conf to sys.config using conform escript
+    if [ -f "$CONFORM_SCHEMA_PATH" ]; then
+        if [ -f "$CONFORM_CONF_PATH" ]; then
+            EXTRA_OPTS="$EXTRA_OPTS -conform_schema ${CONFORM_SCHEMA_PATH} -conform_config $CONFORM_CONF_PATH"
+
+            __conform="$REL_DIR/conform"
+            # Clobbers input sys.config
+            "$BINDIR"/escript "$__conform" --code-path "$__conform_code_path" --conf "$CONFORM_CONF_PATH" --schema "$CONFORM_SCHEMA_PATH" --config "$SYS_CONFIG_PATH" --output-dir "$(dirname $SYS_CONFIG_PATH)"
+            exit_status="$?"
+            if [ "$exit_status" -ne 0 ]; then
+                exit "$exit_status"
+            fi
+            if ! grep -q '^%%' "$SYS_CONFIG_PATH" ; then
+                tmpfile=$(mktemp "${SYS_CONFIG_PATH}.XXXXXX")
+                echo "%%Generated - edit $RELEASE_CONFIG_DIR/$REL_NAME.conf or $RELEASE_CONFIG_DIR/$REL_NAME.conf/sys.config" >> "$tmpfile"
+                cat "${SYS_CONFIG_PATH}" >> $tmpfile
+                mv "$tmpfile" "${SYS_CONFIG_PATH}"
+            fi
+        else
+            echo "missing .conf, expected it at $CONFORM_CONF_PATH"
+            exit 1
+        fi
     fi
 fi


### PR DESCRIPTION
I don't know, if it is best solution. But, sometimes you don't want to generate sys.config. 

Use case, implementing CLI with commands or escript, so and you want to allow another users to execute commands.
If sys.config will be replaced by another user, the release willn't be startable. To prevent this, I propose to introduce CONFORM_IGNORE environment.

If there is better solution, I would like to know.