### PR TITLE
Fix --key

### DIFF
--- a/lib/mix/tasks/conform.effective.ex
+++ b/lib/mix/tasks/conform.effective.ex
@@ -180,8 +180,8 @@ defmodule Mix.Tasks.Conform.Effective do
     options = case {app, key, schema} do
       {nil, nil, nil}  -> %{:type => :all}
       {_, _, true} -> %{:type => :schema}
-      {^app, _, _} -> %{:type => :app, :app => app |> String.to_atom}
-      {_, ^key, _} -> %{:type => :key, :key => key}
+      {^app, nil, nil} -> %{:type => :app, :app => app |> String.to_atom}
+      {nil, ^key, nil} -> %{:type => :key, :key => key}
     end
     options = Map.put(options, :output, output)
 


### PR DESCRIPTION
Documentation mention ``--key`` arg for ``conform.effective``. I was playing with is as I got confused a bit, that configuration changes are not effective without release (basically #138). Passing ``--key`` to ``conform.effective`` will not work with the following error:
```
** (ArgumentError) argument error
    :erlang.binary_to_atom(nil, :utf8)
    lib/mix/tasks/conform.effective.ex:183: Mix.Tasks.Conform.Effective.parse_args/1
    lib/mix/tasks/conform.effective.ex:48: Mix.Tasks.Conform.Effective.run/1
    (mix) lib/mix/task.ex:301: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:75: Mix.CLI.run_task/2
```

I believe, that the issue is with the logic in the `case` statement, as we actually do care about the value of ``key`` for ``app`` branch, it has to be ``nil``. With ``_`` the ``app`` gets bound to ``nil`` when ``key`` is set.

Attached patch fixes issue for me.