### PR TITLE
hooks: improve error handling on conffile syntax errors

### DIFF
--- a/priv/bin/post_configure.sh
+++ b/priv/bin/post_configure.sh
@@ -31,9 +31,11 @@ if [ -f "$CONFORM_SCHEMA_PATH" ]; then
 
         __conform="$REL_DIR/conform"
         # Clobbers input sys.config
-        "$BINDIR"/escript "$__conform" --code-path "$__conform_code_path" --conf "$CONFORM_CONF_PATH" --schema "$CONFORM_SCHEMA_PATH" --config "$SYS_CONFIG_PATH" --output-dir "$(dirname $SYS_CONFIG_PATH)"
-        exit_status="$?"
-        if [ "$exit_status" -ne 0 ]; then
+        if ! result="$("$BINDIR"/escript "$__conform" --code-path "$__conform_code_path" --conf "$CONFORM_CONF_PATH" --schema "$CONFORM_SCHEMA_PATH" --config "$SYS_CONFIG_PATH" --output-dir "$(dirname $SYS_CONFIG_PATH)")"; then
+            exit_status="$?"
+            echo "Error reading $CONFORM_CONF_PATH . This may be due to syntax errors or unquoted values" >&2
+            echo "The parser reported:" >&2
+            echo "$result" >&2
             exit "$exit_status"
         fi
         if ! grep -q '^%%' "$SYS_CONFIG_PATH" ; then

--- a/priv/bin/pre_upgrade.sh
+++ b/priv/bin/pre_upgrade.sh
@@ -33,9 +33,11 @@ if [ -f "$CONFORM_SCHEMA_PATH" ]; then
 
         __conform="$REL_DIR/../$TARGET_VERSION/conform"
         # Clobbers input sys.config
-        result="$("$BINDIR/escript" "$__conform" --conf "$CONFORM_CONF_PATH" --schema "$CONFORM_SCHEMA_PATH" --config "$REL_DIR/../$TARGET_VERSION/sys.config" --output-dir "$REL_DIR/../$TARGET_VERSION")"
-        exit_status="$?"
-        if [ "$exit_status" -ne 0 ]; then
+        if ! result="$("$BINDIR/escript" "$__conform" --conf "$CONFORM_CONF_PATH" --schema "$CONFORM_SCHEMA_PATH" --config "$REL_DIR/../$TARGET_VERSION/sys.config" --output-dir "$REL_DIR/../$TARGET_VERSION")"; then
+            exit_status="$?"
+            echo "Error reading $CONFORM_CONF_PATH . This may be due to syntax errors or unquoted values" >&2
+            echo "The parser reported:" >&2
+            echo "$result" >&2
             exit "$exit_status"
         fi
         tmpfile=$(mktemp "${SYS_CONFIG_PATH}.XXXXXX")


### PR DESCRIPTION
note that hooks run under 'set -e' so execution aborts as soon as conform
exits with an error, unless we wrap it in an 'if'.

With this patch, errors due to a bad conffile give a useful msg in the
commandline or log output.